### PR TITLE
fix table test multiplication operator

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -12,7 +12,7 @@ func DoMath(num1, num2 int, op string) (int, error) {
 	case "-":
 		return num1 - num2, nil
 	case "*":
-		return num1 + num2, nil
+		return num1 * num2, nil
 	case "/":
 		if num2 == 0 {
 			return 0, errors.New("division by zero")


### PR DESCRIPTION
Perhaps the multiplication operator is incorrect and I made a pull request.

The test passed before, but I think that was because the arguments specified in the test code were 2 and 2.
If it was 2 and 3, the test would not pass.

(Of course, the subject of this sample code is table tests, so I don't think this part is so important.)